### PR TITLE
Add Web Bluetooth API in new Hardware category

### DIFF
--- a/features.json
+++ b/features.json
@@ -346,6 +346,19 @@
       }
     }
   ],
+  "Hardware": [
+    {
+      "name": "Web Bluetooth",
+      "contact": "",
+      "status": "favorable",
+      "description": "Access user-selected Bluetooth devices over GATT",
+      "urls": {
+        "bugzilla": "",
+        "documentation": "https://developers.google.com/web/updates/2015/07/interact-with-ble-devices-on-the-web",
+        "specification": "https://webbluetoothcg.github.io/web-bluetooth/"
+      }
+    }
+  ],
   "JavaScript": [
     {
       "name": "Array.prototype.includes",


### PR DESCRIPTION
I'd love to know what is Mozilla's opinion on the Web Bluetooth API project.

https://www.w3.org/community/web-bluetooth/
https://github.com/WebBluetoothCG/web-bluetooth
